### PR TITLE
Add interface to `select` call

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -61,6 +61,7 @@ impl iso7816::App for FuzzAppImpl {
 impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for FuzzAppImpl {
     fn select(
         &mut self,
+        _interface: iso7816::Interface,
         _apdu: &apdu_dispatch::Command,
         _reply: &mut apdu_dispatch::response::Data,
     ) -> AppResult {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@ pub trait App<const C: usize, const R: usize>: iso7816::App {
     /// Given parsed APDU for select command.
     /// Write response data back to buf, and return length of payload.  Return APDU Error code on error.
     /// Alternatively, the app can defer the response until later by returning it in `poll()`.
-    fn select(&mut self, apdu: &Command<C>, reply: &mut Data<R>) -> Result;
+    fn select(&mut self, interface: Interface, apdu: &Command<C>, reply: &mut Data<R>) -> Result;
 
     /// Deselects the app. This is the result of another app getting selected.
     /// App should clear any sensitive state and reset security indicators.

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -381,7 +381,9 @@ impl<'pipe> ApduDispatch<'pipe> {
             info!("Selected app");
             let mut response = response::Data::new();
             let result = match &self.buffer.raw {
-                RawApduBuffer::Request(apdu) => app.select(apdu, &mut response),
+                RawApduBuffer::Request(apdu) => {
+                    app.select(self.current_interface, apdu, &mut response)
+                }
                 _ => panic!("Unexpected buffer state."),
             };
             if result.is_ok() {

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -49,7 +49,12 @@ impl iso7816::App for TestApp1 {
 
 // This app echos to Ins code 0x10
 impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for TestApp1 {
-    fn select(&mut self, _apdu: &Command, _reply: &mut response::Data) -> AppResult {
+    fn select(
+        &mut self,
+        _interface: dispatch::Interface,
+        _apdu: &Command,
+        _reply: &mut response::Data,
+    ) -> AppResult {
         Ok(())
     }
 
@@ -119,7 +124,12 @@ impl iso7816::App for TestApp2 {
 
 // This app echos to Ins code 0x20
 impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for TestApp2 {
-    fn select(&mut self, _apdu: &Command, _reply: &mut response::Data) -> AppResult {
+    fn select(
+        &mut self,
+        _interface: dispatch::Interface,
+        _apdu: &Command,
+        _reply: &mut response::Data,
+    ) -> AppResult {
         Ok(())
     }
 
@@ -166,7 +176,12 @@ impl iso7816::App for PanicApp {
 
 // This app echos to Ins code 0x20
 impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for PanicApp {
-    fn select(&mut self, _apdu: &Command, _reply: &mut response::Data) -> AppResult {
+    fn select(
+        &mut self,
+        _interface: dispatch::Interface,
+        _apdu: &Command,
+        _reply: &mut response::Data,
+    ) -> AppResult {
         panic!("Dont call the panic app");
     }
 


### PR DESCRIPTION
This allows application that do not support NFC to reject operations coming from NFC Previously Select calls could not be rejected.

In case of a rejected `Select` call however this leads to a state where nothing is selected. Should we restore the previous selection?

See https://github.com/Nitrokey/nitrokey-3-firmware/issues/301 for more context.