### PR TITLE
Replace iso7816::Command with iso7816::command::CommandView

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/trussed-dev/apdu-dispatch"
 
 [workspace.dependencies]
-iso7816 = "0.1.1"
+iso7816 = "0.1.2"
 
 [patch.crates-io]
 apdu-app.path = "app"

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Extract `app` module from `apdu-dispatch` 0.2.0 into a separate crate.
+- Replace `iso7816::Command` with `iso7816::command::CommandView` in the `App` trait and remove the `C` parameter.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,15 +1,20 @@
 #![no_std]
 
-pub use iso7816::{Command, Data, Interface, Status};
+pub use iso7816::{command::CommandView, Data, Interface, Status};
 
 pub type Result = iso7816::Result<()>;
 
 /// An App can receive and respond APDUs at behest of the ApduDispatch.
-pub trait App<const C: usize, const R: usize>: iso7816::App {
+pub trait App<const R: usize>: iso7816::App {
     /// Given parsed APDU for select command.
     /// Write response data back to buf, and return length of payload.  Return APDU Error code on error.
     /// Alternatively, the app can defer the response until later by returning it in `poll()`.
-    fn select(&mut self, interface: Interface, apdu: &Command<C>, reply: &mut Data<R>) -> Result;
+    fn select(
+        &mut self,
+        interface: Interface,
+        apdu: CommandView<'_>,
+        reply: &mut Data<R>,
+    ) -> Result;
 
     /// Deselects the app. This is the result of another app getting selected.
     /// App should clear any sensitive state and reset security indicators.
@@ -17,5 +22,5 @@ pub trait App<const C: usize, const R: usize>: iso7816::App {
 
     /// Given parsed APDU for app when selected.
     /// Write response data back to buf, and return length of payload.  Return APDU Error code on error.
-    fn call(&mut self, interface: Interface, apdu: &Command<C>, reply: &mut Data<R>) -> Result;
+    fn call(&mut self, interface: Interface, apdu: CommandView<'_>, reply: &mut Data<R>) -> Result;
 }

--- a/dispatch/CHANGELOG.md
+++ b/dispatch/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Move the `app` module into a separate crate, `apdu-app`, and re-export it.
+- Replace `iso7816::Command` with `iso7816::command::CommandView` in the `App` trait and remove the `C` parameter.
 
 ## [0.2.0]
 

--- a/dispatch/tests/dispatch.rs
+++ b/dispatch/tests/dispatch.rs
@@ -1,6 +1,5 @@
-use apdu_dispatch::app::{App, Result as AppResult};
+use apdu_dispatch::app::{App, CommandView, Result as AppResult};
 use apdu_dispatch::dispatch;
-use apdu_dispatch::Command;
 use apdu_dispatch::{interchanges, response};
 use hex_literal::hex;
 use interchange::Channel;
@@ -48,11 +47,11 @@ impl iso7816::App for TestApp1 {
 }
 
 // This app echos to Ins code 0x10
-impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for TestApp1 {
+impl App<{ apdu_dispatch::response::SIZE }> for TestApp1 {
     fn select(
         &mut self,
         _interface: dispatch::Interface,
-        _apdu: &Command,
+        _apdu: CommandView<'_>,
         _reply: &mut response::Data,
     ) -> AppResult {
         Ok(())
@@ -63,7 +62,7 @@ impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> fo
     fn call(
         &mut self,
         _: dispatch::Interface,
-        apdu: &Command,
+        apdu: CommandView<'_>,
         reply: &mut response::Data,
     ) -> AppResult {
         println!("TestApp1::call");
@@ -123,11 +122,11 @@ impl iso7816::App for TestApp2 {
 }
 
 // This app echos to Ins code 0x20
-impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for TestApp2 {
+impl App<{ apdu_dispatch::response::SIZE }> for TestApp2 {
     fn select(
         &mut self,
         _interface: dispatch::Interface,
-        _apdu: &Command,
+        _apdu: CommandView<'_>,
         _reply: &mut response::Data,
     ) -> AppResult {
         Ok(())
@@ -138,7 +137,7 @@ impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> fo
     fn call(
         &mut self,
         _: dispatch::Interface,
-        apdu: &Command,
+        apdu: CommandView<'_>,
         reply: &mut response::Data,
     ) -> AppResult {
         println!("TestApp2::call");
@@ -175,11 +174,11 @@ impl iso7816::App for PanicApp {
 }
 
 // This app echos to Ins code 0x20
-impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for PanicApp {
+impl App<{ apdu_dispatch::response::SIZE }> for PanicApp {
     fn select(
         &mut self,
         _interface: dispatch::Interface,
-        _apdu: &Command,
+        _apdu: CommandView<'_>,
         _reply: &mut response::Data,
     ) -> AppResult {
         panic!("Dont call the panic app");
@@ -192,7 +191,7 @@ impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> fo
     fn call(
         &mut self,
         _: dispatch::Interface,
-        _apdu: &Command,
+        _apdu: CommandView<'_>,
         _reply: &mut response::Data,
     ) -> AppResult {
         panic!("Dont call the panic app");

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -53,11 +53,11 @@ impl iso7816::App for FuzzAppImpl {
     }
 }
 
-impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> for FuzzAppImpl {
+impl App<{ apdu_dispatch::response::SIZE }> for FuzzAppImpl {
     fn select(
         &mut self,
         _interface: iso7816::Interface,
-        _apdu: &apdu_dispatch::Command,
+        _apdu: apdu_dispatch::app::CommandView<'_>,
         _reply: &mut apdu_dispatch::response::Data,
     ) -> AppResult {
         Ok(())
@@ -68,7 +68,7 @@ impl App<{ apdu_dispatch::command::SIZE }, { apdu_dispatch::response::SIZE }> fo
     fn call(
         &mut self,
         _: Interface,
-        _apdu: &apdu_dispatch::Command,
+        _apdu: apdu_dispatch::app::CommandView<'_>,
         reply: &mut apdu_dispatch::response::Data,
     ) -> AppResult {
         let (ref data, status) = &self.responses[self.count];
@@ -91,7 +91,7 @@ fuzz_target!(|input: Input| {
         .collect();
     let mut dyn_apps: Vec<_> = apps
         .iter_mut()
-        .map(|s| (s as &mut dyn apdu_dispatch::App<7609, 7609>))
+        .map(|s| (s as &mut dyn apdu_dispatch::App<7609>))
         .collect();
 
     let contact = Channel::new();


### PR DESCRIPTION
This allows us to drop one generic parameter from the App trait and potentially generate more efficient code.