### PR TITLE
Do not deselect applications if the application was not found

### DIFF
--- a/dispatch/tests/dispatch.rs
+++ b/dispatch/tests/dispatch.rs
@@ -326,6 +326,25 @@ fn select_not_found() {
 
 #[test]
 #[serial]
+fn select_not_found_still_selected() {
+    run_apdus(&[
+        // Select
+        &hex!("00A40400 05 0A01000001"),
+        // Ok
+        &hex!("9000"),
+        // Select
+        &hex!("00A40400 05 0A01000100"),
+        // Not found
+        &hex!("6A82"),
+        // Echo app is still selected
+        &hex!("80100000 05 0102030405 00"),
+        // Echo + Ok
+        &hex!("0000000000 0102030405 9000"),
+    ])
+}
+
+#[test]
+#[serial]
 fn select_bad_aid() {
     // Select with an incorrect AID shouldn't crash the application
     run_apdus(&[


### PR DESCRIPTION
From [NIST SP 800-73-4](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf): 

> If the currently selected application is the PIV Card Application when the SELECT command is given
> and the AID in the data field of the SELECT command is an invalid AID not supported by the ICC, then
> the PIV Card Application shall remain the currently selected application and all PIV Card Application
> security status indicators shall remain unchanged.